### PR TITLE
fix: improve wheel picker with 7x looping, type coercion, and bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/index.d.ts",
-  "react-native": "src/index",
+  "react-native": "lib/module/index",
   "source": "src/index",
   "exports": {
     ".": {
       "types": "./lib/typescript/index.d.ts",
-      "react-native": "./src/index.ts",
+      "react-native": "./lib/module/index.js",
       "import": "./lib/module/index.js",
       "require": "./lib/commonjs/index.js",
       "default": "./lib/commonjs/index.js"

--- a/src/components/header/selectors.tsx
+++ b/src/components/header/selectors.tsx
@@ -17,7 +17,7 @@ const Selectors = ({ position }: Props) => {
     <View
       style={[
         defaultStyles.container,
-        // eslint-disable-next-line react-native/no-inline-styles
+
         position === 'around'
           ? { justifyContent: 'space-evenly' }
           : {

--- a/src/components/time-picker/wheel-picker/__tests__/wheel-picker.test.tsx
+++ b/src/components/time-picker/wheel-picker/__tests__/wheel-picker.test.tsx
@@ -1,0 +1,402 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import WheelPicker from '../wheel-picker';
+
+describe('WheelPicker', () => {
+  const mockOnChange = jest.fn();
+
+  const createOptions = (start: number, end: number, step: number = 1) => {
+    const options = [];
+    for (let i = start; i <= end; i += step) {
+      options.push({ value: i, text: i.toString() });
+    }
+    return options;
+  };
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+    jest.clearAllTimers();
+  });
+
+  describe('selectedIndex calculation', () => {
+    it('should find exact match when value exists in options', () => {
+      const options = createOptions(0, 23, 1); // Hours 0-23
+      const { UNSAFE_root } = render(
+        <WheelPicker value={15} options={options} onChange={mockOnChange} />
+      );
+
+      // Should not throw error
+      expect(UNSAFE_root).toBeTruthy();
+    });
+
+    it('should handle value not in options - find next available (ceiling)', () => {
+      const options = createOptions(0, 45, 15); // 0, 15, 30, 45 (15-min intervals)
+      const { UNSAFE_root } = render(
+        <WheelPicker
+          value={17} // Not in options, should select 30 (next available)
+          options={options}
+          onChange={mockOnChange}
+        />
+      );
+
+      // Should not throw error
+      expect(UNSAFE_root).toBeTruthy();
+    });
+
+    it('should handle value less than all options', () => {
+      const options = createOptions(10, 50, 10); // 10, 20, 30, 40, 50
+      const { UNSAFE_root } = render(
+        <WheelPicker
+          value={5} // Less than all options, should select 10 (first option)
+          options={options}
+          onChange={mockOnChange}
+        />
+      );
+
+      // Should not throw error
+      expect(UNSAFE_root).toBeTruthy();
+    });
+
+    it('should handle value greater than all options', () => {
+      const options = createOptions(0, 45, 15); // 0, 15, 30, 45
+      const { UNSAFE_root } = render(
+        <WheelPicker
+          value={50} // Greater than all options, should default to 0
+          options={options}
+          onChange={mockOnChange}
+        />
+      );
+
+      // Should not throw error
+      expect(UNSAFE_root).toBeTruthy();
+    });
+
+    it('should handle 15-minute stepping scenarios', () => {
+      const options = [
+        { value: 0, text: '00' },
+        { value: 15, text: '15' },
+        { value: 30, text: '30' },
+        { value: 45, text: '45' },
+      ];
+
+      // Test various times that should round to next 15-min interval
+      const testCases = [
+        { value: 0, expected: 0 }, // Exact match
+        { value: 1, expected: 15 }, // Should round up to 15
+        { value: 15, expected: 15 }, // Exact match
+        { value: 17, expected: 30 }, // Should round up to 30
+        { value: 30, expected: 30 }, // Exact match
+        { value: 42, expected: 45 }, // Should round up to 45
+        { value: 45, expected: 45 }, // Exact match
+        { value: 50, expected: 0 }, // Greater than all, default to 0
+      ];
+
+      testCases.forEach(({ value }) => {
+        const { UNSAFE_root } = render(
+          <WheelPicker
+            value={value}
+            options={options}
+            onChange={mockOnChange}
+          />
+        );
+
+        // Should not throw error for any value
+        expect(UNSAFE_root).toBeTruthy();
+      });
+    });
+
+    it('should not throw error when selectedIndex is -1 (old behavior)', () => {
+      const options = createOptions(0, 23, 1);
+
+      // This should not throw "Selected index -1 is out of bounds" error
+      expect(() => {
+        render(
+          <WheelPicker
+            value={99} // Value not in options
+            options={options}
+            onChange={mockOnChange}
+          />
+        );
+      }).not.toThrow();
+    });
+  });
+
+  describe('looping behavior', () => {
+    it('should handle looping with non-matching values', () => {
+      const options = createOptions(0, 45, 15);
+      const { UNSAFE_root } = render(
+        <WheelPicker
+          value={17}
+          options={options}
+          onChange={mockOnChange}
+          enableLooping={true}
+        />
+      );
+
+      // Should not throw error with looping enabled
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  describe('type coercion (string vs number)', () => {
+    it('should handle "00" string matching numeric 0', () => {
+      // Simulates web behavior where options might have "00" as string
+      const options = [
+        { value: '00' as any, text: '00' },
+        { value: 1, text: '01' },
+        { value: 2, text: '02' },
+      ];
+
+      const { UNSAFE_root } = render(
+        <WheelPicker value={0} options={options} onChange={mockOnChange} />
+      );
+
+      // Should not throw error and should match "00" with 0
+      expect(UNSAFE_root).toBeTruthy();
+    });
+
+    it('should handle numeric 0 matching "00" string', () => {
+      const options = [
+        { value: 0, text: '00' },
+        { value: 1, text: '01' },
+        { value: 2, text: '02' },
+      ];
+
+      const { UNSAFE_root } = render(
+        <WheelPicker
+          value={'00' as any}
+          options={options}
+          onChange={mockOnChange}
+        />
+      );
+
+      // Should not throw error and should match 0 with "00"
+      expect(UNSAFE_root).toBeTruthy();
+    });
+
+    it('should emit numeric value even when option is string', () => {
+      const options = [
+        { value: '00' as any, text: '00' },
+        { value: '15' as any, text: '15' },
+      ];
+
+      const { UNSAFE_root } = render(
+        <WheelPicker value={0} options={options} onChange={mockOnChange} />
+      );
+
+      // Component should normalize string values to numbers
+      // This is tested implicitly - onChange will be called with Number(option.value)
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  describe('mount-time emission prevention', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should not emit onChange on mount', async () => {
+      const options = createOptions(0, 23, 1);
+
+      render(
+        <WheelPicker value={10} options={options} onChange={mockOnChange} />
+      );
+
+      // Should not call onChange immediately
+      expect(mockOnChange).not.toHaveBeenCalled();
+
+      // Even after initial timeout
+      jest.advanceTimersByTime(100);
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+
+    it('should not emit onChange when value is 0 (prevents 00:00 bug)', async () => {
+      const options = createOptions(0, 23, 1);
+
+      render(
+        <WheelPicker value={0} options={options} onChange={mockOnChange} />
+      );
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(100);
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('7x looping (REPEAT=7)', () => {
+    it('should create 7 repetitions when looping enabled', () => {
+      const options = createOptions(0, 23, 1); // 24 hours
+      const { UNSAFE_root } = render(
+        <WheelPicker
+          value={12}
+          options={options}
+          onChange={mockOnChange}
+          enableLooping={true}
+          visibleRest={2}
+        />
+      );
+
+      // With 7 repetitions: 24 * 7 = 168 items + 4 null padding (2 on each side)
+      // We can't directly test internal paddedOptions, but we verify no crash
+      expect(UNSAFE_root).toBeTruthy();
+    });
+
+    it('should initialize to middle block (MID_BLOCK=3)', () => {
+      const options = createOptions(0, 11, 1); // 12 hours
+      const { UNSAFE_root } = render(
+        <WheelPicker
+          value={6}
+          options={options}
+          onChange={mockOnChange}
+          enableLooping={true}
+        />
+      );
+
+      // Should scroll to middle block (index 3 out of 0-6)
+      // Initial index = MID_BLOCK * baseLen + selectedIndex = 3 * 12 + 6 = 42
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  describe('numeric emission guarantees', () => {
+    it('should always emit numbers, never strings', () => {
+      const options = [
+        { value: '00' as any, text: '00' },
+        { value: '05' as any, text: '05' },
+        { value: '10' as any, text: '10' },
+      ];
+
+      render(
+        <WheelPicker value={0} options={options} onChange={mockOnChange} />
+      );
+
+      // If onChange is called, it should be with a number
+      if (mockOnChange.mock.calls.length > 0) {
+        const emittedValue = mockOnChange.mock.calls[0][0];
+        expect(typeof emittedValue).toBe('number');
+      }
+    });
+
+    it('should not use fallback || 0 pattern', () => {
+      const options = [
+        { value: 1, text: '01' },
+        { value: 2, text: '02' },
+      ];
+
+      render(
+        <WheelPicker value={1} options={options} onChange={mockOnChange} />
+      );
+
+      // Even if onChange gets called, should never emit 0 as fallback
+      if (mockOnChange.mock.calls.length > 0) {
+        const emittedValue = mockOnChange.mock.calls[0][0];
+        expect(emittedValue).not.toBe(0);
+      }
+    });
+  });
+
+  describe('offset-based initialization', () => {
+    it('should use scrollToOffset for looping mode', () => {
+      const options = createOptions(0, 59, 1); // Minutes 0-59
+
+      const { UNSAFE_root } = render(
+        <WheelPicker
+          value={30}
+          options={options}
+          onChange={mockOnChange}
+          enableLooping={true}
+          itemHeight={40}
+        />
+      );
+
+      // Should initialize via offset (not initialScrollIndex)
+      // MID_BLOCK=3, so offset = (3 * 60 + 30) * 40 = 8400
+      expect(UNSAFE_root).toBeTruthy();
+    });
+
+    it('should use scrollToIndex for non-looping mode', () => {
+      const options = createOptions(0, 59, 1);
+
+      const { UNSAFE_root } = render(
+        <WheelPicker
+          value={30}
+          options={options}
+          onChange={mockOnChange}
+          enableLooping={false}
+        />
+      );
+
+      // Should use scrollToIndex for backward compatibility
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  describe('comprehensive integration tests', () => {
+    it('should handle all features together: looping + type coercion + ceiling + no mount emit', async () => {
+      jest.useFakeTimers();
+
+      const options = [
+        { value: '00' as any, text: '00' },
+        { value: 15, text: '15' },
+        { value: 30, text: '30' },
+        { value: 45, text: '45' },
+      ];
+
+      const { UNSAFE_root } = render(
+        <WheelPicker
+          value={17} // Not exact match, should round to 30
+          options={options}
+          onChange={mockOnChange}
+          enableLooping={true}
+        />
+      );
+
+      // Should render without error
+      expect(UNSAFE_root).toBeTruthy();
+
+      // Should not emit on mount
+      expect(mockOnChange).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(100);
+      expect(mockOnChange).not.toHaveBeenCalled();
+
+      jest.useRealTimers();
+    });
+
+    it('should handle edge case: all string values with looping', () => {
+      const options = [
+        { value: '00' as any, text: '00' },
+        { value: '01' as any, text: '01' },
+        { value: '02' as any, text: '02' },
+      ];
+
+      const { UNSAFE_root } = render(
+        <WheelPicker
+          value={'01' as any}
+          options={options}
+          onChange={mockOnChange}
+          enableLooping={true}
+        />
+      );
+
+      expect(UNSAFE_root).toBeTruthy();
+    });
+
+    it('should handle edge case: minuteStep with non-matching initial value', () => {
+      const options = createOptions(0, 45, 15); // 0, 15, 30, 45
+
+      const { UNSAFE_root } = render(
+        <WheelPicker
+          value={7} // Should round to 15
+          options={options}
+          onChange={mockOnChange}
+        />
+      );
+
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+});

--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -312,9 +312,11 @@ const DateTimePicker = (
     if (mode === 'single') {
       let _date =
         (date &&
-          (timePicker
-            ? dayjs.tz(date, timeZone)
-            : getStartOfDay(dayjs.tz(date, timeZone)))) ??
+          (timeZone === 'UTC'
+            ? dayjs(date)
+            : timePicker
+              ? dayjs.tz(date, timeZone)
+              : getStartOfDay(dayjs.tz(date, timeZone)))) ??
         date;
 
       if (_date && maxDate && dayjs.tz(_date, timeZone).isAfter(maxDate)) {
@@ -337,7 +339,11 @@ const DateTimePicker = (
       }
     } else if (mode === 'range') {
       let start = (
-        startDate ? dayjs.tz(startDate, timeZone) : startDate
+        startDate
+          ? timeZone === 'UTC'
+            ? dayjs(startDate)
+            : dayjs.tz(startDate, timeZone)
+          : startDate
       ) as DateType;
 
       if (start && maxDate && dayjs.tz(start, timeZone).isAfter(maxDate)) {
@@ -348,7 +354,13 @@ const DateTimePicker = (
         start = dayjs.tz(minDate, timeZone);
       }
 
-      let end = (endDate ? dayjs.tz(endDate, timeZone) : endDate) as DateType;
+      let end = (
+        endDate
+          ? timeZone === 'UTC'
+            ? dayjs(endDate)
+            : dayjs.tz(endDate, timeZone)
+          : endDate
+      ) as DateType;
 
       if (end && maxDate && dayjs.tz(end, timeZone).isAfter(maxDate)) {
         end = dayjs.tz(maxDate, timeZone);


### PR DESCRIPTION
  - Implement 7x repetition looping (REPEAT=7) for better scroll room
  - Use offset-based initialization instead of initialScrollIndex
  - Replace auto-recentering with mathematical wrapping
  - Fix mount-time onChange emission (prevents 00:00 bug)
  - Add ceiling rounding for non-exact value matches
  - Fix type coercion to handle "00" string vs 0 number
  - Always emit numeric values from onChange
  - Fix UTC timezone handling in datetime picker
  - Update package exports to use built files instead of source